### PR TITLE
Add SEO and social sharing metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,21 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Animated Code + Markdown Box</title>
+    <title>Yazdan Ranjbar</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Personal website of Yazdan Ranjbar">
+    <meta name="author" content="Yazdan Ranjbar">
+    <meta property="og:site_name" content="Yazdan Ranjbar">
+    <meta property="og:title" content="Yazdan Ranjbar">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/image01.jpeg">
+    <meta property="og:description" content="Personal website of Yazdan Ranjbar">
+    <meta property="og:url" content="https://yazdanra.com">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Yazdan Ranjbar">
+    <meta name="twitter:description" content="Personal website of Yazdan Ranjbar">
+    <meta name="twitter:image" content="assets/image01.jpeg">
+    <link rel="canonical" href="https://yazdanra.com">
     <!-- highlight.js CSS (light & dark, toggle with JS) -->
     <link id="hljs-theme" rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css">


### PR DESCRIPTION
## Summary
- enrich meta tags for descriptions, Open Graph, and Twitter cards
- set canonical URL and author details for better link previews

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c348f9c44832597b52911ae8585d9