### PR TITLE
Fix Safari unsafe area background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <meta name="twitter:title" content="Yazdan Ranjbar">
     <meta name="twitter:description" content="Experienced software developer with 7+ years in the SDLC, specializing in APIs, integrations, and DevOps.">
     <meta name="twitter:image" content="assets/image01.jpeg">
+    <meta name="theme-color" content="#f8f9fa">
     <!-- highlight.js CSS (light & dark, toggle with JS) -->
     <link id="hljs-theme" rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github.min.css">
@@ -126,7 +127,7 @@
             height: 100%;
             margin: 0;
             padding: 0;
-            background: transparent;
+            background: var(--bg);
             color: var(--fg);
             width: 100vw;
             min-height: 100vh;
@@ -565,6 +566,14 @@
         }
         // Toggle icon
         toggleBtn.textContent = m === 'dark' ? '🌙' : '🌞';
+        // Update theme-color meta tag to match current theme
+        const metaTheme = document.querySelector('meta[name="theme-color"]');
+        if (metaTheme) {
+            metaTheme.setAttribute(
+                'content',
+                getComputedStyle(document.documentElement).getPropertyValue('--bg').trim()
+            );
+        }
         drawBgCode();
     }
 


### PR DESCRIPTION
## Summary
- ensure unsafe areas adopt the page theme by giving html/body the themed background color
- add and update `theme-color` meta tag so mobile browsers color their chrome correctly

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c3a70675083259057279373824c2f